### PR TITLE
Adding monarch.screen_exists(id)

### DIFF
--- a/example/main.script
+++ b/example/main.script
@@ -1,6 +1,14 @@
 local monarch = require "monarch.monarch"
 
 function init(self)
-	monarch.show(hash("menu"))
+	self.wait = true
 	msg.post("@render:/", "clear_color", { color = vmath.vector4(0.4, 0.6, 0.8,1.0) })
+end
+
+function update(self)
+	-- Ensure that the initial screen has had enough time to register
+	if self.wait == true and monarch.screen_exists(hash("menu")) then
+		self.wait = false
+		monarch.show(hash("menu"))
+	end	
 end

--- a/monarch/monarch.lua
+++ b/monarch/monarch.lua
@@ -152,6 +152,13 @@ function M.data(id)
 	return screens[id].data
 end
 
+--- Checks to see if a screen id is registered
+-- @param id Id of the screen to check if is registered
+-- @return True or False if the screen id is registered or not
+function M.screen_exists(id)
+	return screens[id] ~= nil
+end
+
 --- Show a new screen
 -- @param id Id of the screen to show
 -- @param options Table with options when showing the screen (can be nil). Valid values:


### PR DESCRIPTION
In some projects, may need to wait until initial screen has been registered before attempting to show it.

I had this happen in a project (otherwise adding a small wait worked) which is why I added it.