### PR TITLE
Add sequential loading flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ The options table can contain the following fields:
 * ```clear``` (boolean) - If the `clear` flag is set Monarch will search the stack for the screen that is to be shown. If the screen already exists in the stack and the clear flag is set Monarch will remove all screens between the current top and the screen in question.
 * ```reload``` (boolean) - If the `reload` flag is set Monarch will reload the collection proxy if it's already loaded (this can happen if the previous screen was a popup).
 * ```no_stack``` (boolean) - If the `no_stack` flag is set Monarch will load the screen without adding it to the screen stack.
+* ```sequential``` (boolean) - If the `sequential` flag is set Monarch will start loading the screen only after the previous screen finished transitioning out.
 
 
 ### monarch.hide(screen_id, [callback])

--- a/monarch/monarch.lua
+++ b/monarch/monarch.lua
@@ -647,6 +647,8 @@ end
 -- 		* clear - Set to true if the stack should be cleared down to an existing instance of the screen
 -- 		* reload - Set to true if screen should be reloaded if it already exists in the stack and is loaded.
 --				   This would be the case if doing a show() from a popup on the screen just below the popup.
+-- 		* sequential - Set to true to wait for the previous screen to show itself out before starting the
+--				   show in transition even when transitioning to a different scene ID.
 -- @param data (*) - Optional data to set on the screen. Can be retrieved by the data() function
 -- @param cb (function) - Optional callback to invoke when screen is shown
 function M.show(id, options, data, cb)
@@ -692,7 +694,7 @@ function M.show(id, options, data, cb)
 						-- wait until we are done if showing the same screen as is already visible
 						local same_screen = top and top.id == screen.id
 						show_out(top, screen, callbacks.track())
-						if same_screen then
+						if same_screen or (options and options.sequential) then
 							callbacks.yield_until_done()
 						end
 					end


### PR DESCRIPTION
Sometimes, you might want to wait for the previous scene to fully transition out before transitioning the new scene in (a fade-to-black transition is such an example). This also has the benefit of not having both scenes in memory at the same time and masking the few slow loading frames of a scene in-between the two scenes (on a black screen).

This is exactly how we did scene transitions in Interrogation (though we rolled our own scene manager there).

This was already happening when transitioning to the same scene ID, so I just added a flag to have that behaviour on-demand.