### PR TITLE
Only allow editor script to target .gui

### DIFF
--- a/monarch/editor-script/make_monarch.editor_script
+++ b/monarch/editor-script/make_monarch.editor_script
@@ -66,9 +66,9 @@ function M.get_commands()
             query = {
                 selection = {type = "resource", cardinality = "one"}
             },
-            active = function(opts)
+            active = function(opts)                
                 local path = editor.get(opts.selection, "path")
-                return ends_with(path, ".gui") or ends_with(path, ".collection") or ends_with(path, ".gui_script")
+                return ends_with(path, ".gui")
             end,
             run = function(opts)
                 create_files(opts.selection)

--- a/monarch/editor-script/make_monarch.editor_script
+++ b/monarch/editor-script/make_monarch.editor_script
@@ -66,7 +66,7 @@ function M.get_commands()
             query = {
                 selection = {type = "resource", cardinality = "one"}
             },
-            active = function(opts)                
+            active = function(opts)
                 local path = editor.get(opts.selection, "path")
                 return ends_with(path, ".gui")
             end,


### PR DESCRIPTION
The editor extension does not work if .collection / .gui_script are targets so they should not be targetable