### PR TITLE
Improved handling of unregistered screens

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -10,7 +10,7 @@ jobs:
           - uses: actions/checkout@v1
           - uses: actions/setup-java@v1
             with:
-                java-version: '11'
+                java-version: '17'
           - name: Run.sh
             env:
                 DEFOLD_USER: bjorn.ritzl@gmail.com

--- a/monarch/monarch.lua
+++ b/monarch/monarch.lua
@@ -390,6 +390,7 @@ local function change_context(screen)
 end
 
 local function unload(screen, force)
+	if screen.unregistered then return end
 	if screen.proxy then
 		log("unload() proxy", screen.id)
 		if screen.auto_preload and not force then
@@ -509,6 +510,7 @@ end
 
 local function transition(screen, message_id, message, wait)
 	log("transition()", screen.id)
+	if screen.unregistered then return end
 	if screen.transition_url then
 		screen.wait_for = WAITFOR_TRANSITION_DONE
 		msg.post(screen.transition_url, message_id, message)
@@ -532,6 +534,7 @@ end
 
 local function focus_lost(screen, next_screen)
 	log("focus_lost()", screen.id)
+	if screen.unregistered then return end
 	if screen.focus_url then
 		msg.post(screen.focus_url, M.FOCUS.LOST, { id = next_screen and next_screen.id })
 		-- if there's no transition on the screen losing focus and it gets


### PR DESCRIPTION
Unregistered screens are ignored from further processing in Monarch. This is typically not a problem, unless screens are unregistered while other screen operations such as transitions take place at the same time.

Fixes #92 