### PR TITLE
Guard DEPRECATED transition_id overwriting transition_url

### DIFF
--- a/monarch/monarch.lua
+++ b/monarch/monarch.lua
@@ -509,7 +509,9 @@ local function load(screen)
 		msg.post(screen.proxy, MSG_ENABLE)
 	elseif screen.factory then
 		screen.factory_ids = collectionfactory.create(screen.factory)
-		screen.transition_url = screen.factory_ids[screen.transition_id]
+		if screen.transition_id then
+			screen.transition_url = screen.factory_ids[screen.transition_id]
+		end
 		screen.focus_url = screen.factory_ids[screen.focus_id]
 	end
 	screen.loaded = true


### PR DESCRIPTION
In v4.50, transition_id is set to `nil` because it is deprecated. This results in screens that are loaded via collection_factory to have their transition_url field overwritten to be `nil` which means that the `on_transition` function skips the transition. This change simply guards against the situation where it overwrites the transition_url.

Fixes #99 