### PR TITLE
Fix a problem when sequential doesn't work without second argument in back function

### DIFF
--- a/monarch/monarch.lua
+++ b/monarch/monarch.lua
@@ -995,7 +995,6 @@ function M.back(options, data, cb)
 	-- case when back(data, nil)
 	elseif options ~= nil and data == nil and cb == nil then
 		data = options
-		options = nil
 	end
 
 	queue_action(function(action_done)


### PR DESCRIPTION
When we call `monarch.back({ sequential = true })` sequential doesn't have any effect because we set `options = nil` if we don't have second and third parameters.

My changes have not broken something. Because we don't pass the option argument and we have strict condition `options and options.sequential`


