### PR TITLE
find_transition_screen shouldn't rely on screen.transition_url

### DIFF
--- a/monarch/monarch.lua
+++ b/monarch/monarch.lua
@@ -160,7 +160,7 @@ end
 local function find_transition_screen(url_to_find)
 	local function find(url)
 		for _,screen in pairs(screens) do
-			if screen.transition_url == url or screen.script == url or screen.proxy == url then
+			if screen.script == url or screen.proxy == url then
 				return screen
 			end
 		end


### PR DESCRIPTION
`screen.transition_url` is set inside `M.on_transition(id, fn)`.  
When multiple handlers are registered from the main script, a random callback may be invoked due to the current implementation of `find_transition_screen`.
